### PR TITLE
Add CI and Lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - '**'
+jobs:
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: [1.13, 1.14]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
+    - name: Run tests
+      run: |
+        go test -v -race ./...
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run lint
+      uses: actions-contrib/golangci-lint@v1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+run:
+  skip-dirs:
+    - .github
+  # Allow failure
+  # Remove this line later! (Or change value to 1)
+  issues-exit-code: 0
+
+linters-settings:
+  gocyclo:
+    min-complexity: 15
+  gofmt:
+    simplify: true
+  misspell:
+    locale: UK
+
+linters:
+  enable:
+    - gofmt
+    - gocyclo
+    - misspell
+  disable-all: false
+  fast: false
+  

--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -3,11 +3,11 @@ package cmd
 import "github.com/mingrammer/cfmt"
 
 const (
-	placeholderUsage = "This is a placeholder"
+	placeholderUsage     = "This is a placeholder"
 	placeholderUsageText = "This is a longer text"
 )
 
-func notImplemented(){
+func notImplemented() {
 	_, _ = cfmt.Infoln("This command is currently not implemented.\n" +
 		"Please check current status at https://github.com/Wulfheart/gyv.")
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"archive/zip"
 	"fmt"
-	"github.com/mingrammer/cfmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -11,6 +10,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/mingrammer/cfmt"
 
 	"github.com/urfave/cli/v2"
 )
@@ -122,7 +123,7 @@ var initCmd = &cli.Command{
 			return nil
 		})
 		if err != nil {
-		    return err
+			return err
 		}
 
 		_, _ = cfmt.Successln("Initialized project at ", dir)

--- a/cmd/make_controller.go
+++ b/cmd/make_controller.go
@@ -5,8 +5,8 @@ import (
 )
 
 var makeControllerCmd = &cli.Command{
-	Name:      "make:controller",
-	Category:  "make",
+	Name:     "make:controller",
+	Category: "make",
 	Action: func(context *cli.Context) error {
 		// err := changeWorkingDirectoryToRoot()
 		// if err != nil {

--- a/cmd/make_model.go
+++ b/cmd/make_model.go
@@ -3,9 +3,9 @@ package cmd
 import "github.com/urfave/cli/v2"
 
 var makeModelCmd = &cli.Command{
-	Name:      "make:model",
-	Category:  "make",
-	Action:   func(c *cli.Context) error {
+	Name:     "make:model",
+	Category: "make",
+	Action: func(c *cli.Context) error {
 		notImplemented()
 		return nil
 	},

--- a/cmd/make_request.go
+++ b/cmd/make_request.go
@@ -3,9 +3,9 @@ package cmd
 import "github.com/urfave/cli/v2"
 
 var makeRequestCmd = &cli.Command{
-	Name:      "make:request",
-	Category:  "make",
-	Action:    func(c *cli.Context) error {
+	Name:     "make:request",
+	Category: "make",
+	Action: func(c *cli.Context) error {
 		notImplemented()
 		return nil
 	},

--- a/cmd/migrate_fresh.go
+++ b/cmd/migrate_fresh.go
@@ -3,9 +3,9 @@ package cmd
 import "github.com/urfave/cli/v2"
 
 var migrateFreshCmd = &cli.Command{
-	Name:      "migrate:fresh",
-	Category:  "migrate",
-	Action:    func(c *cli.Context) error {
+	Name:     "migrate:fresh",
+	Category: "migrate",
+	Action: func(c *cli.Context) error {
 		notImplemented()
 		return nil
 	},

--- a/cmd/migrate_run.go
+++ b/cmd/migrate_run.go
@@ -3,9 +3,9 @@ package cmd
 import "github.com/urfave/cli/v2"
 
 var migrateRunCmd = &cli.Command{
-	Name:      "migrate:run",
-	Category:  "migrate",
-	Action:    func(c *cli.Context) error {
+	Name:     "migrate:run",
+	Category: "migrate",
+	Action: func(c *cli.Context) error {
 		notImplemented()
 		return nil
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/mingrammer/cfmt"
 	"github.com/urfave/cli/v2"
-	"os"
 )
 
 func Run() {

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -3,8 +3,8 @@ package cmd
 import "github.com/urfave/cli/v2"
 
 var routesCmd = &cli.Command{
-	Name:      "routes",
-	Action:    func(c *cli.Context) error {
+	Name: "routes",
+	Action: func(c *cli.Context) error {
 		notImplemented()
 		return nil
 	},

--- a/cmd/seed.go
+++ b/cmd/seed.go
@@ -3,8 +3,8 @@ package cmd
 import "github.com/urfave/cli/v2"
 
 var seedCmd = &cli.Command{
-	Name:      "seed",
-	Action:    func(c *cli.Context) error {
+	Name: "seed",
+	Action: func(c *cli.Context) error {
 		notImplemented()
 		return nil
 	},

--- a/gyv.go
+++ b/gyv.go
@@ -4,7 +4,6 @@ import (
 	"github.com/Wulfheart/gyv/cmd"
 )
 
-
 func main() {
 	// Dev
 	// err := os.Chdir("C:\\Users\\Alex\\Documents\\tmp\\test")


### PR DESCRIPTION
This PR adds a configuration for [golangci-lint](https://github.com/golangci/golangci-lint) and a Github Action workflow for tests and lint.

Notes:
- The lint job is currently allowed to fail. Please remove `issues-exit-code: 0` in `.golangci.yml` after merging this branch.
- The lint config uses more or less the same rules as the framework, but feel free to change it to whatever you prefer.
- The issues reported by the gofmt linter have been fixed in this PR.
- The CI workflow doesn't measure and report coverage. That would be a nice plus but I can't set it up for you.
- I advise you to make the new jobs required in the branch protection rules.